### PR TITLE
Receive Splunk API path as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ $ npm run build
 $ wt cron schedule \
     --name auth0-logs-to-splunk \
     --secret AUTH0_DOMAIN="YOUR_AUTH0_DOMAIN" \
-    --secret AUTH0_GLOBAL_CLIENT_ID="YOUR_AUTH0_GLOBAL_CLIENT_ID" \
-    --secret AUTH0_GLOBAL_CLIENT_SECRET="YOUR_AUTH0_GLOBAL_CLIENT_SECRET" \
+    --secret AUTH0_CLIENT_ID="YOUR_AUTH0_CLIENT_ID" \
+    --secret AUTH0_CLIENT_SECRET="YOUR_AUTH0_CLIENT_SECRET" \
     --secret LOG_LEVEL="1" \
     --secret LOG_TYPES="s,f" \
     --secret SPLUNK_URL="SPLUNK_URL" \

--- a/build/bundle.js
+++ b/build/bundle.js
@@ -54,13 +54,13 @@ module.exports =
 	var express = __webpack_require__(5);
 	var Webtask = __webpack_require__(6);
 	var app = express();
-	var SplunkLogger = __webpack_require__(9).Logger;
-	var Request = __webpack_require__(13);
-	var memoizer = __webpack_require__(14);
+	var SplunkLogger = __webpack_require__(17).Logger;
+	var Request = __webpack_require__(14);
+	var memoizer = __webpack_require__(20);
 
 	function lastLogCheckpoint(req, res) {
 	  var ctx = req.webtaskContext;
-	  var required_settings = ['AUTH0_DOMAIN', 'AUTH0_CLIENT_ID', 'AUTH0_CLIENT_SECRET', 'SPLUNK_URL', 'SPLUNK_TOKEN', 'SPLUNK_COLLECTOR_PORT'];
+	  var required_settings = ['AUTH0_DOMAIN', 'AUTH0_CLIENT_ID', 'AUTH0_CLIENT_SECRET', 'SPLUNK_URL', 'SPLUNK_TOKEN'];
 	  var missing_settings = required_settings.filter(function (setting) {
 	    return !ctx.data[setting];
 	  });
@@ -91,6 +91,7 @@ module.exports =
 	      token: ctx.data.SPLUNK_TOKEN,
 	      url: ctx.data.SPLUNK_URL,
 	      port: ctx.data.SPLUNK_COLLECTOR_PORT || 8088,
+	      path: ctx.data.SPLUNK_COLLECTOR_PATH || '/services/collector/event/1.0',
 	      maxBatchCount: 0 // Manually flush events
 	    };
 
@@ -457,15 +458,23 @@ module.exports =
 /* 6 */
 /***/ function(module, exports, __webpack_require__) {
 
+	exports.auth0 = __webpack_require__(7);
 	exports.fromConnect = exports.fromExpress = fromConnect;
 	exports.fromHapi = fromHapi;
 	exports.fromServer = exports.fromRestify = fromServer;
 
-
 	// API functions
 
+	function addAuth0(func) {
+	    func.auth0 = function (options) {
+	        return exports.auth0(func, options);
+	    }
+
+	    return func;
+	}
+
 	function fromConnect (connectFn) {
-	    return function (context, req, res) {
+	    return addAuth0(function (context, req, res) {
 	        var normalizeRouteRx = createRouteNormalizationRx(req.x_wt.jtn);
 
 	        req.originalUrl = req.url;
@@ -473,7 +482,7 @@ module.exports =
 	        req.webtaskContext = attachStorageHelpers(context);
 
 	        return connectFn(req, res);
-	    };
+	    });
 	}
 
 	function fromHapi(server) {
@@ -486,17 +495,17 @@ module.exports =
 	        request.webtaskContext = webtaskContext;
 	    });
 
-	    return function (context, req, res) {
+	    return addAuth0(function (context, req, res) {
 	        var dispatchFn = server._dispatch();
 
 	        webtaskContext = attachStorageHelpers(context);
 
 	        dispatchFn(req, res);
-	    };
+	    });
 	}
 
 	function fromServer(httpServer) {
-	    return function (context, req, res) {
+	    return addAuth0(function (context, req, res) {
 	        var normalizeRouteRx = createRouteNormalizationRx(req.x_wt.jtn);
 
 	        req.originalUrl = req.url;
@@ -504,7 +513,7 @@ module.exports =
 	        req.webtaskContext = attachStorageHelpers(context);
 
 	        return httpServer.emit('request', req, res);
-	    };
+	    });
 	}
 
 
@@ -534,7 +543,7 @@ module.exports =
 
 
 	    function readNotAvailable(path, options, cb) {
-	        var Boom = __webpack_require__(7);
+	        var Boom = __webpack_require__(15);
 
 	        if (typeof options === 'function') {
 	            cb = options;
@@ -545,8 +554,8 @@ module.exports =
 	    }
 
 	    function readFromPath(path, options, cb) {
-	        var Boom = __webpack_require__(7);
-	        var Request = __webpack_require__(8);
+	        var Boom = __webpack_require__(15);
+	        var Request = __webpack_require__(16);
 
 	        if (typeof options === 'function') {
 	            cb = options;
@@ -569,7 +578,7 @@ module.exports =
 	    }
 
 	    function writeNotAvailable(path, data, options, cb) {
-	        var Boom = __webpack_require__(7);
+	        var Boom = __webpack_require__(15);
 
 	        if (typeof options === 'function') {
 	            cb = options;
@@ -580,8 +589,8 @@ module.exports =
 	    }
 
 	    function writeToPath(path, data, options, cb) {
-	        var Boom = __webpack_require__(7);
-	        var Request = __webpack_require__(8);
+	        var Boom = __webpack_require__(15);
+	        var Request = __webpack_require__(16);
 
 	        if (typeof options === 'function') {
 	            cb = options;
@@ -606,18 +615,463 @@ module.exports =
 
 /***/ },
 /* 7 */
-/***/ function(module, exports) {
+/***/ function(module, exports, __webpack_require__) {
 
-	module.exports = require("boom");
+	var url = __webpack_require__(8);
+	var error = __webpack_require__(9);
+	var handleAppEndpoint = __webpack_require__(10);
+	var handleLogin = __webpack_require__(12);
+	var handleCallback = __webpack_require__(13);
+
+	module.exports = function (webtask, options) {
+	    if (typeof webtask !== 'function' || webtask.length !== 3) {
+	        throw new Error('The auth0() function can only be called on webtask functions with the (ctx, req, res) signature.');
+	    }
+	    if (!options) {
+	        options = {};
+	    }
+	    if (typeof options !== 'object') {
+	        throw new Error('The options parameter must be an object.');
+	    }
+	    if (options.scope && typeof options.scope !== 'string') {
+	        throw new Error('The scope option, if specified, must be a string.');
+	    }
+	    if (options.authorized && ['string','function'].indexOf(typeof options.authorized) < 0 && !Array.isArray(options.authorized)) {
+	        throw new Error('The authorized option, if specified, must be a string or array of strings with e-mail or domain names, or a function that accepts (ctx, req) and returns boolean.');
+	    }
+	    if (options.exclude && ['string','function'].indexOf(typeof options.exclude) < 0 && !Array.isArray(options.exclude)) {
+	        throw new Error('The exclude option, if specified, must be a string or array of strings with URL paths that do not require authentication, or a function that accepts (ctx, req, appPath) and returns boolean.');
+	    }
+	    if (options.clientId && typeof options.clientId !== 'function') {
+	        throw new Error('The clientId option, if specified, must be a function that accepts (ctx, req) and returns an Auth0 Client ID.');
+	    }
+	    if (options.clientSecret && typeof options.clientSecret !== 'function') {
+	        throw new Error('The clientSecret option, if specified, must be a function that accepts (ctx, req) and returns an Auth0 Client Secret.');
+	    }
+	    if (options.domain && typeof options.domain !== 'function') {
+	        throw new Error('The domain option, if specified, must be a function that accepts (ctx, req) and returns an Auth0 Domain.');
+	    }
+	    if (options.webtaskSecret && typeof options.webtaskSecret !== 'function') {
+	        throw new Error('The webtaskSecret option, if specified, must be a function that accepts (ctx, req) and returns a key to be used to sign issued JWT tokens.');
+	    }
+	    if (options.getApiKey && typeof options.getApiKey !== 'function') {
+	        throw new Error('The getApiKey option, if specified, must be a function that accepts (ctx, req) and returns an apiKey associated with the request.');
+	    }
+	    if (options.loginSuccess && typeof options.loginSuccess !== 'function') {
+	        throw new Error('The loginSuccess option, if specified, must be a function that accepts (ctx, req, res, baseUrl) and generates a response.');
+	    }
+	    if (options.loginError && typeof options.loginError !== 'function') {
+	        throw new Error('The loginError option, if specified, must be a function that accepts (error, ctx, req, res, baseUrl) and generates a response.');
+	    }
+
+	    options.clientId = options.clientId || function (ctx, req) {
+	        return ctx.secrets.AUTH0_CLIENT_ID;
+	    };
+	    options.clientSecret = options.clientSecret || function (ctx, req) {
+	        return ctx.secrets.AUTH0_CLIENT_SECRET;
+	    };
+	    options.domain = options.domain || function (ctx, req) {
+	        return ctx.secrets.AUTH0_DOMAIN;
+	    };
+	    options.webtaskSecret = options.webtaskSecret || function (ctx, req) {
+	        // By default we don't expect developers to specify WEBTASK_SECRET when
+	        // creating authenticated webtasks. In this case we will use webtask token
+	        // itself as a JWT signing key. The webtask token of a named webtask is secret
+	        // and it contains enough entropy (jti, iat, ca) to pass
+	        // for a symmetric key. Using webtask token ensures that the JWT signing secret 
+	        // remains constant for the lifetime of the webtask; however regenerating 
+	        // the webtask will invalidate previously issued JWTs. 
+	        return ctx.secrets.WEBTASK_SECRET || req.x_wt.token;
+	    };
+	    options.getApiKey = options.getApiKey || function (ctx, req) {
+	        if (req.headers.authorization && req.headers.authorization.split(' ')[0] === 'Bearer') {
+	            return req.headers.authorization.split(' ')[1];
+	        } else if (req.query && req.query.apiKey) {
+	            return req.query.apiKey;
+	        }
+	        return null;
+	    };
+	    options.loginSuccess = options.loginSuccess || function (ctx, req, res, baseUrl) {
+	        res.writeHead(302, { Location: baseUrl + '?apiKey=' + ctx.apiKey });
+	        return res.end();
+	    };
+	    options.loginError = options.loginError || function (error, ctx, req, res, baseUrl) {
+	        if (req.method === 'GET') {
+	            if (error.redirect) {
+	                res.writeHead(302, { Location: error.redirect });
+	                return res.end(JSON.stringify(error));
+	            }
+	            res.writeHead(error.code || 401, { 
+	                'Content-Type': 'text/html', 
+	                'Cache-Control': 'no-cache' 
+	            });
+	            return res.end(getNotAuthorizedHtml(baseUrl + '/login'));
+	        }
+	        else {
+	            // Reject all other requests
+	            return error(error, res);
+	        }            
+	    };
+	    if (typeof options.authorized === 'string') {
+	        options.authorized = [ options.authorized ];
+	    }
+	    if (Array.isArray(options.authorized)) {
+	        var authorized = [];
+	        options.authorized.forEach(function (a) {
+	            authorized.push(a.toLowerCase());
+	        });
+	        options.authorized = function (ctx, res) {
+	            if (ctx.user.email_verified) {
+	                for (var i = 0; i < authorized.length; i++) {
+	                    var email = ctx.user.email.toLowerCase();
+	                    if (email === authorized[i] || authorized[i][0] === '@' && email.indexOf(authorized[i]) > 1) {
+	                        return true;
+	                    }
+	                }
+	            }
+	            return false;
+	        }
+	    }
+	    if (typeof options.exclude === 'string') {
+	        options.exclude = [ options.exclude ];
+	    }
+	    if (Array.isArray(options.exclude)) {
+	        var exclude = options.exclude;
+	        options.exclude = function (ctx, res, appPath) {
+	            return exclude.indexOf(appPath) > -1;
+	        }
+	    }
+
+	    return createAuthenticatedWebtask(webtask, options);
+	};
+
+	function createAuthenticatedWebtask(webtask, options) {
+
+	    // Inject middleware into the HTTP pipeline before the webtask handler
+	    // to implement authentication endpoints and perform authentication 
+	    // and authorization.
+
+	    return function (ctx, req, res) {
+	        if (!req.x_wt.jtn || !req.x_wt.container) {
+	            return error({
+	                code: 400,
+	                message: 'Auth0 authentication can only be used with named webtasks.'
+	            }, res);
+	        }
+
+	        var routingInfo = getRoutingInfo(req);
+	        if (!routingInfo) {
+	            return error({
+	                code: 400,
+	                message: 'Error processing request URL path.'
+	            }, res);
+	        }
+	        switch (req.method === 'GET' && routingInfo.appPath) {
+	            case '/login': handleLogin(options, ctx, req, res, routingInfo); break;
+	            case '/callback': handleCallback(options, ctx, req, res, routingInfo); break;
+	            default: handleAppEndpoint(webtask, options, ctx, req, res, routingInfo); break;
+	        };
+	        return;
+	    };
+	}
+
+	function getRoutingInfo(req) {
+	    var routingInfo = url.parse(req.url, true);
+	    var segments = routingInfo.pathname.split('/');
+	    if (segments[1] === 'api' && segments[2] === 'run' && segments[3] === req.x_wt.container && segments[4] === req.x_wt.jtn) {
+	        // Shared domain case: /api/run/{container}/{jtn}
+	        routingInfo.basePath = segments.splice(0, 5).join('/');
+	    }
+	    else if (segments[1] === req.x_wt.container && segments[2] === req.x_wt.jtn) {
+	        // Custom domain case: /{container}/{jtn}
+	        routingInfo.basePath = segments.splice(0, 3).join('/');
+	    }
+	    else {
+	        return null;
+	    }
+	    routingInfo.appPath = '/' + segments.join('/');
+	    routingInfo.baseUrl = [
+	        req.headers['x-forwarded-proto'] || 'https',
+	        '://',
+	        req.headers.host,
+	        routingInfo.basePath
+	    ].join('');
+	    return routingInfo;
+	}
+
+	var notAuthorizedTemplate = function () {/*
+	<!DOCTYPE html5>
+	<html>
+	  <head>
+	    <meta charset="utf-8"/>
+	    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+	    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+	    <link href="https://cdn.auth0.com/styleguide/latest/index.css" rel="stylesheet" />
+	    <title>Access denied</title>
+	  </head>
+	  <body>
+	    <div class="container">
+	      <div class="row text-center">
+	        <h1><a href="https://auth0.com" title="Go to Auth0!"><img src="https://cdn.auth0.com/styleguide/1.0.0/img/badge.svg" alt="Auth0 badge" /></a></h1>
+	        <h1>Not authorized</h1>
+	        <p><a href="##">Try again</a></p>
+	      </div>
+	    </div>
+	  </body>
+	</html>
+	*/}.toString().match(/[^]*\/\*([^]*)\*\/\s*\}$/)[1];
+
+	function getNotAuthorizedHtml(loginUrl) {
+	    return notAuthorizedTemplate.replace('##', loginUrl);
+	}
+
 
 /***/ },
 /* 8 */
 /***/ function(module, exports) {
 
-	module.exports = require("request");
+	module.exports = require("url");
 
 /***/ },
 /* 9 */
+/***/ function(module, exports) {
+
+	module.exports = function (err, res) {
+	    res.writeHead(err.code || 500, { 
+	        'Content-Type': 'application/json',
+	        'Cache-Control': 'no-cache'
+	    });
+	    res.end(JSON.stringify(err));
+	};
+
+
+/***/ },
+/* 10 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var error = __webpack_require__(9);
+
+	module.exports = function (webtask, options, ctx, req, res, routingInfo) {
+	    return options.exclude && options.exclude(ctx, req, routingInfo.appPath)
+	        ? run()
+	        : authenticate();
+
+	    function authenticate() {
+	        var apiKey = options.getApiKey(ctx, req);
+	        if (!apiKey) {
+	            return options.loginError({
+	                code: 401,
+	                message: 'Unauthorized.',
+	                error: 'Missing apiKey.',
+	                redirect: routingInfo.baseUrl + '/login'
+	            }, ctx, req, res, routingInfo.baseUrl);
+	        }
+
+	        // Authenticate
+
+	        var secret = options.webtaskSecret(ctx, req);
+	        if (!secret) {
+	            return error({
+	                code: 400,
+	                message: 'The webtask secret must be provided to allow for validating apiKeys.'
+	            }, res);
+	        }
+
+	        try {
+	            ctx.user = req.user = __webpack_require__(11).verify(apiKey, secret);
+	        }
+	        catch (e) {
+	            return options.loginError({
+	                code: 401,
+	                message: 'Unauthorized.',
+	                error: e.message
+	            }, ctx, req, res, routingInfo.baseUrl);       
+	        }
+
+	        ctx.apiKey = apiKey;
+
+	        // Authorize
+
+	        if  (options.authorized && !options.authorized(ctx, req)) {
+	            return options.loginError({
+	                code: 403,
+	                message: 'Forbidden.'
+	            }, ctx, req, res, routingInfo.baseUrl);        
+	        }
+
+	        return run();
+	    }
+
+	    function run() {
+	        // Route request to webtask code
+	        return webtask(ctx, req, res);
+	    }
+	};
+
+
+/***/ },
+/* 11 */
+/***/ function(module, exports) {
+
+	module.exports = require("jsonwebtoken");
+
+/***/ },
+/* 12 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var error = __webpack_require__(9);
+
+	module.exports = function(options, ctx, req, res, routingInfo) {
+	    var authParams = {
+	        clientId: options.clientId(ctx, req),
+	        domain: options.domain(ctx, req)
+	    };
+	    var count = !!authParams.clientId + !!authParams.domain;
+	    var scope = 'openid name email email_verified ' + (options.scope || '');
+	    if (count ===  0) {
+	        // TODO, tjanczuk, support the shared Auth0 application case
+	        return error({
+	            code: 501,
+	            message: 'Not implemented.'
+	        }, res);
+	        // Neither client id or domain are specified; use shared Auth0 settings
+	        // var authUrl = 'https://auth0.auth0.com/i/oauth2/authorize'
+	        //     + '?response_type=code'
+	        //     + '&audience=https://auth0.auth0.com/userinfo'
+	        //     + '&scope=' + encodeURIComponent(scope)
+	        //     + '&client_id=' + encodeURIComponent(routingInfo.baseUrl)
+	        //     + '&redirect_uri=' + encodeURIComponent(routingInfo.baseUrl + '/callback');
+	        // res.writeHead(302, { Location: authUrl });
+	        // return res.end();
+	    }
+	    else if (count === 2) {
+	        // Use custom Auth0 account
+	        var authUrl = 'https://' + authParams.domain + '/authorize' 
+	            + '?response_type=code'
+	            + '&scope=' + encodeURIComponent(scope)
+	            + '&client_id=' + encodeURIComponent(authParams.clientId)
+	            + '&redirect_uri=' + encodeURIComponent(routingInfo.baseUrl + '/callback');
+	        res.writeHead(302, { Location: authUrl });
+	        return res.end();
+	    }
+	    else {
+	        return error({
+	            code: 400,
+	            message: 'Both or neither Auth0 Client ID and Auth0 domain must be specified.'
+	        }, res);
+	    }
+	};
+
+
+/***/ },
+/* 13 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var error = __webpack_require__(9);
+
+	module.exports = function (options, ctx, req, res, routingInfo) {
+	    if (!ctx.query.code) {
+	        return options.loginError({
+	            code: 401,
+	            message: 'Authentication error.',
+	            callbackQuery: ctx.query
+	        }, ctx, req, res, routingInfo.baseUrl);
+	    }
+
+	    var authParams = {
+	        clientId: options.clientId(ctx, req),
+	        domain: options.domain(ctx, req),
+	        clientSecret: options.clientSecret(ctx, req)
+	    };
+	    var count = !!authParams.clientId + !!authParams.domain + !!authParams.clientSecret;
+	    if (count !== 3) {
+	        return error({
+	            code: 400,
+	            message: 'Auth0 Client ID, Client Secret, and Auth0 Domain must be specified.'
+	        }, res);
+	    }
+
+	    return __webpack_require__(14)
+	        .post('https://' + authParams.domain + '/oauth/token')
+	        .type('form')
+	        .send({
+	            client_id: authParams.clientId,
+	            client_secret: authParams.clientSecret,
+	            redirect_uri: routingInfo.baseUrl + '/callback',
+	            code: ctx.query.code,
+	            grant_type: 'authorization_code'
+	        })
+	        .timeout(15000)
+	        .end(function (err, ares) {
+	            if (err || !ares.ok) {
+	                return options.loginError({
+	                    code: 502,
+	                    message: 'OAuth code exchange completed with error.',
+	                    error: err && err.message,
+	                    auth0Status: ares && ares.status,
+	                    auth0Response: ares && (ares.body || ares.text)
+	                }, ctx, req, res, routingInfo.baseUrl);
+	            }
+
+	            return issueApiKey(ares.body.id_token);
+	        });
+
+	    function issueApiKey(id_token) {
+	        var jwt = __webpack_require__(11);
+	        var claims;
+	        try {
+	            claims = jwt.decode(id_token);
+	        }
+	        catch (e) {
+	            return options.loginError({
+	                code: 502,
+	                message: 'Cannot parse id_token returned from Auth0.',
+	                id_token: id_token,
+	                error: e.message
+	            }, ctx, req, res, routingInfo.baseUrl);
+	        }
+
+	        // Issue apiKey by re-signing the id_token claims 
+	        // with configured secret (webtask token by default).
+
+	        var secret = options.webtaskSecret(ctx, req);
+	        if (!secret) {
+	            return error({
+	                code: 400,
+	                message: 'The webtask secret must be be provided to allow for issuing apiKeys.'
+	            }, res);
+	        }
+
+	        claims.iss = routingInfo.baseUrl;
+	        req.user = ctx.user = claims;
+	        ctx.apiKey = jwt.sign(claims, secret);
+
+	        // Perform post-login action (redirect to /?apiKey=... by default)
+	        return options.loginSuccess(ctx, req, res, routingInfo.baseUrl);
+	    }
+	};
+
+
+/***/ },
+/* 14 */
+/***/ function(module, exports) {
+
+	module.exports = require("superagent");
+
+/***/ },
+/* 15 */
+/***/ function(module, exports) {
+
+	module.exports = require("boom");
+
+/***/ },
+/* 16 */
+/***/ function(module, exports) {
+
+	module.exports = require("request");
+
+/***/ },
+/* 17 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -636,8 +1090,8 @@ module.exports =
 	 * under the License.
 	 */
 
-	var SplunkLogger = __webpack_require__(10);
-	var utils = __webpack_require__(12);
+	var SplunkLogger = __webpack_require__(18);
+	var utils = __webpack_require__(19);
 
 	module.exports = {
 	    Logger: SplunkLogger,
@@ -645,7 +1099,7 @@ module.exports =
 	};
 
 /***/ },
-/* 10 */
+/* 18 */
 /***/ function(module, exports, __webpack_require__) {
 
 	/*
@@ -664,10 +1118,10 @@ module.exports =
 	 * under the License.
 	 */
 
-	var request = __webpack_require__(8);
-	var url = __webpack_require__(11);
+	var request = __webpack_require__(16);
+	var url = __webpack_require__(8);
 
-	var utils = __webpack_require__(12);
+	var utils = __webpack_require__(19);
 
 	/**
 	 * Default error handler for <code>SplunkLogger</code>.
@@ -700,8 +1154,8 @@ module.exports =
 	}
 
 	/**
-	 * Constructs a SplunkLogger, to send events to Splunk Enterprise or Splunk Cloud
-	 * via HTTP Event Collector. See <code>defaultConfig</code> for default
+	 * Constructs a SplunkLogger, to send events to Splunk Enterprise or Splunk Cloud 
+	 * via HTTP Event Collector. See <code>defaultConfig</code> for default 
 	 * configuration settings.
 	 *
 	 * @example
@@ -733,7 +1187,7 @@ module.exports =
 	 * @param {string} [config.protocol=https] - Protocol used to communicate with the Splunk Enterprise or Splunk Cloud server, <code>http</code> or <code>https</code>.
 	 * @param {number} [config.port=8088] - HTTP Event Collector port on the Splunk Enterprise or Splunk Cloud server.
 	 * @param {string} [config.url] - URL string to pass to {@link https://nodejs.org/api/url.html#url_url_parsing|url.parse}. This will try to set
-	 * <code>host</code>, <code>path</code>, <code>protocol</code>, <code>port</code>, <code>url</code>. Any of these values will be overwritten if
+	 * <code>host</code>, <code>path</code>, <code>protocol</code>, <code>port</code>, <code>url</code>. Any of these values will be overwritten if 
 	 * the corresponding property is set on <code>config</code>.
 	 * @param {string} [config.level=info] - Logging level to use, will show up as the <code>severity</code> field of an event, see
 	 *  [SplunkLogger.levels]{@link SplunkLogger#levels} for common levels.
@@ -830,7 +1284,7 @@ module.exports =
 	    if (this._timerID) {
 	        this._disableTimer();
 	    }
-
+	    
 	    // If batch interval is changed, update the config property
 	    if (this.config) {
 	        this.config.batchInterval = interval;
@@ -925,7 +1379,7 @@ module.exports =
 	        var startTimer = !this._timerID && ret.batchInterval > 0;
 	        // Has the interval timer already started, and the interval changed to a different duration?
 	        var changeTimer = this._timerID && this._timerDuration !== ret.batchInterval && ret.batchInterval > 0;
-
+	        
 	        // Enable the timer
 	        if (startTimer || changeTimer) {
 	            this._enableTimer(ret.batchInterval);
@@ -1047,7 +1501,7 @@ module.exports =
 	    var body = this._initializeMetadata(context);
 	    var time = utils.formatTime(body.time || Date.now());
 	    body.time = time.toString();
-
+	    
 	    body.event = this.eventFormatter(context.message, context.severity || defaultConfig.level);
 	    return body;
 	};
@@ -1060,7 +1514,6 @@ module.exports =
 	 * @private
 	 */
 	SplunkLogger.prototype._post = function(requestOptions, callback) {
-	  console.log(requestOptions);
 	    request.post(requestOptions, callback);
 	};
 
@@ -1139,7 +1592,7 @@ module.exports =
 	        }
 	    );
 	};
-
+	 
 	/**
 	 * Sends or queues data to be sent based on batching settings.
 	 * Default behavior is to send immediately.
@@ -1148,8 +1601,8 @@ module.exports =
 	 * var SplunkLogger = require("splunk-logging").Logger;
 	 * var config = {
 	 *     token: "your-token-here"
-	 * };
-	 *
+	 * }; 
+	 * 
 	 * var logger = new SplunkLogger(config);
 	 *
 	 * // Payload to send to HTTP Event Collector.
@@ -1165,7 +1618,7 @@ module.exports =
 	 *         index: "main",
 	 *         host: "farm.local",
 	 *     }
-	 * };
+	 * }; 
 	 *
 	 * // The callback is only used if maxBatchCount=1, or
 	 * // batching thresholds have been exceeded.
@@ -1192,7 +1645,7 @@ module.exports =
 	 */
 	SplunkLogger.prototype.send = function(context, callback) {
 	    context = this._initializeContext(context);
-
+	    
 	    // Store the context, and its estimated length
 	    var currentEvent = JSON.stringify(this._makeBody(context));
 	    this.serializedContextQueue.push(currentEvent);
@@ -1226,7 +1679,7 @@ module.exports =
 	    var context = {
 	        message: data
 	    };
-
+	    
 	    this._sendEvents(context, callback);
 	};
 
@@ -1234,13 +1687,7 @@ module.exports =
 
 
 /***/ },
-/* 11 */
-/***/ function(module, exports) {
-
-	module.exports = require("url");
-
-/***/ },
-/* 12 */
+/* 19 */
 /***/ function(module, exports) {
 
 	/**
@@ -1552,55 +1999,79 @@ module.exports =
 
 
 /***/ },
-/* 13 */
-/***/ function(module, exports) {
-
-	module.exports = require("superagent");
-
-/***/ },
-/* 14 */
+/* 20 */
 /***/ function(module, exports, __webpack_require__) {
 
-	/* WEBPACK VAR INJECTION */(function(setImmediate) {const LRU = __webpack_require__(17);
-	const _ = __webpack_require__(18);
-	const lru_params =  [ 'max', 'maxAge', 'length', 'dispose', 'stale' ];
+	const LRU        = __webpack_require__(21);
+	const _          = __webpack_require__(22);
+	const lru_params = [ 'max', 'maxAge', 'length', 'dispose', 'stale' ];
 
 	module.exports = function (options) {
-	  var cache = new LRU(_.pick(options, lru_params));
-	  var load = options.load;
-	  var hash = options.hash;
+	  const cache      = new LRU(_.pick(options, lru_params));
+	  const load       = options.load;
+	  const hash       = options.hash;
+	  const bypass     = options.bypass;
+	  const itemMaxAge = options.itemMaxAge;
+	  const loading    = new Map();
 
-	  var result = function () {
-	    var args = _.toArray(arguments);
-	    var parameters = args.slice(0, -1);
-	    var callback = args.slice(-1).pop();
+	  if (options.disable) {
+	    return load;
+	  }
+
+	  const result = function () {
+	    const args       = _.toArray(arguments);
+	    const parameters = args.slice(0, -1);
+	    const callback   = args.slice(-1).pop();
+	    const self       = this;
 
 	    var key;
+
+	    if (bypass && bypass.apply(self, parameters)) {
+	      return load.apply(self, args);
+	    }
 
 	    if (parameters.length === 0 && !hash) {
 	      //the load function only receives callback.
 	      key = '_';
 	    } else {
-	      key = hash.apply(options, parameters);
+	      key = hash.apply(self, parameters);
 	    }
 
 	    var fromCache = cache.get(key);
 
 	    if (fromCache) {
-	      return setImmediate.apply(null, [callback, null].concat(fromCache));
+	      return callback.apply(null, [null].concat(fromCache));
 	    }
 
-	    load.apply(null, parameters.concat(function (err) {
-	      if (err) {
-	        return callback(err);
-	      }
+	    if (!loading.get(key)) {
+	      loading.set(key, []);
 
-	      cache.set(key, _.toArray(arguments).slice(1));
+	      load.apply(self, parameters.concat(function (err) {
+	        const args = _.toArray(arguments);
 
-	      return callback.apply(null, arguments);
+	        //we store the result only if the load didn't fail.
+	        if (!err) {
+	          const result = args.slice(1);
+	          if (itemMaxAge) {
+	            cache.set(key, result, itemMaxAge.apply(self, parameters.concat(result)));
+	          } else {
+	            cache.set(key, result);
+	          }
+	        }
 
-	    }));
+	        //immediately call every other callback waiting
+	        loading.get(key).forEach(function (callback) {
+	          callback.apply(null, args);
+	        });
 
+	        loading.delete(key);
+	        /////////
+
+	        callback.apply(null, args);
+	      }));
+	    } else {
+	      loading.get(key).push(callback);
+	    }
 	  };
 
 	  result.keys = cache.keys.bind(cache);
@@ -1610,14 +2081,26 @@ module.exports =
 
 
 	module.exports.sync = function (options) {
-	  var cache = new LRU(_.pick(options, lru_params));
-	  var load = options.load;
-	  var hash = options.hash;
+	  const cache = new LRU(_.pick(options, lru_params));
+	  const load = options.load;
+	  const hash = options.hash;
+	  const disable = options.disable;
+	  const bypass = options.bypass;
+	  const self = this;
+	  const itemMaxAge = options.itemMaxAge;
 
-	  var result = function () {
+	  if (disable) {
+	    return load;
+	  }
+
+	  const result = function () {
 	    var args = _.toArray(arguments);
 
-	    var key = hash.apply(options, args);
+	    if (bypass && bypass.apply(self, arguments)) {
+	      return load.apply(self, arguments);
+	    }
+
+	    var key = hash.apply(self, args);
 
 	    var fromCache = cache.get(key);
 
@@ -1625,9 +2108,12 @@ module.exports =
 	      return fromCache;
 	    }
 
-	    var result = load.apply(null, args);
-
-	    cache.set(key, result);
+	    const result = load.apply(self, args);
+	    if (itemMaxAge) {
+	      cache.set(key, result, itemMaxAge.apply(self, args.concat([ result ])));
+	    } else {
+	      cache.set(key, result);
+	    }
 
 	    return result;
 	  };
@@ -1636,195 +2122,16 @@ module.exports =
 
 	  return result;
 	};
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(15).setImmediate))
-
-/***/ },
-/* 15 */
-/***/ function(module, exports, __webpack_require__) {
-
-	/* WEBPACK VAR INJECTION */(function(setImmediate, clearImmediate) {var nextTick = __webpack_require__(16).nextTick;
-	var apply = Function.prototype.apply;
-	var slice = Array.prototype.slice;
-	var immediateIds = {};
-	var nextImmediateId = 0;
-
-	// DOM APIs, for completeness
-
-	exports.setTimeout = function() {
-	  return new Timeout(apply.call(setTimeout, window, arguments), clearTimeout);
-	};
-	exports.setInterval = function() {
-	  return new Timeout(apply.call(setInterval, window, arguments), clearInterval);
-	};
-	exports.clearTimeout =
-	exports.clearInterval = function(timeout) { timeout.close(); };
-
-	function Timeout(id, clearFn) {
-	  this._id = id;
-	  this._clearFn = clearFn;
-	}
-	Timeout.prototype.unref = Timeout.prototype.ref = function() {};
-	Timeout.prototype.close = function() {
-	  this._clearFn.call(window, this._id);
-	};
-
-	// Does not start the time, just sets up the members needed.
-	exports.enroll = function(item, msecs) {
-	  clearTimeout(item._idleTimeoutId);
-	  item._idleTimeout = msecs;
-	};
-
-	exports.unenroll = function(item) {
-	  clearTimeout(item._idleTimeoutId);
-	  item._idleTimeout = -1;
-	};
-
-	exports._unrefActive = exports.active = function(item) {
-	  clearTimeout(item._idleTimeoutId);
-
-	  var msecs = item._idleTimeout;
-	  if (msecs >= 0) {
-	    item._idleTimeoutId = setTimeout(function onTimeout() {
-	      if (item._onTimeout)
-	        item._onTimeout();
-	    }, msecs);
-	  }
-	};
-
-	// That's not how node.js implements it but the exposed api is the same.
-	exports.setImmediate = typeof setImmediate === "function" ? setImmediate : function(fn) {
-	  var id = nextImmediateId++;
-	  var args = arguments.length < 2 ? false : slice.call(arguments, 1);
-
-	  immediateIds[id] = true;
-
-	  nextTick(function onNextTick() {
-	    if (immediateIds[id]) {
-	      // fn.call() is faster so we optimize for the common use-case
-	      // @see http://jsperf.com/call-apply-segu
-	      if (args) {
-	        fn.apply(null, args);
-	      } else {
-	        fn.call(null);
-	      }
-	      // Prevent ids from leaking
-	      exports.clearImmediate(id);
-	    }
-	  });
-
-	  return id;
-	};
-
-	exports.clearImmediate = typeof clearImmediate === "function" ? clearImmediate : function(id) {
-	  delete immediateIds[id];
-	};
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(15).setImmediate, __webpack_require__(15).clearImmediate))
-
-/***/ },
-/* 16 */
-/***/ function(module, exports) {
-
-	// shim for using process in browser
-
-	var process = module.exports = {};
-	var queue = [];
-	var draining = false;
-	var currentQueue;
-	var queueIndex = -1;
-
-	function cleanUpNextTick() {
-	    draining = false;
-	    if (currentQueue.length) {
-	        queue = currentQueue.concat(queue);
-	    } else {
-	        queueIndex = -1;
-	    }
-	    if (queue.length) {
-	        drainQueue();
-	    }
-	}
-
-	function drainQueue() {
-	    if (draining) {
-	        return;
-	    }
-	    var timeout = setTimeout(cleanUpNextTick);
-	    draining = true;
-
-	    var len = queue.length;
-	    while(len) {
-	        currentQueue = queue;
-	        queue = [];
-	        while (++queueIndex < len) {
-	            if (currentQueue) {
-	                currentQueue[queueIndex].run();
-	            }
-	        }
-	        queueIndex = -1;
-	        len = queue.length;
-	    }
-	    currentQueue = null;
-	    draining = false;
-	    clearTimeout(timeout);
-	}
-
-	process.nextTick = function (fun) {
-	    var args = new Array(arguments.length - 1);
-	    if (arguments.length > 1) {
-	        for (var i = 1; i < arguments.length; i++) {
-	            args[i - 1] = arguments[i];
-	        }
-	    }
-	    queue.push(new Item(fun, args));
-	    if (queue.length === 1 && !draining) {
-	        setTimeout(drainQueue, 0);
-	    }
-	};
-
-	// v8 likes predictible objects
-	function Item(fun, array) {
-	    this.fun = fun;
-	    this.array = array;
-	}
-	Item.prototype.run = function () {
-	    this.fun.apply(null, this.array);
-	};
-	process.title = 'browser';
-	process.browser = true;
-	process.env = {};
-	process.argv = [];
-	process.version = ''; // empty string to avoid regexp issues
-	process.versions = {};
-
-	function noop() {}
-
-	process.on = noop;
-	process.addListener = noop;
-	process.once = noop;
-	process.off = noop;
-	process.removeListener = noop;
-	process.removeAllListeners = noop;
-	process.emit = noop;
-
-	process.binding = function (name) {
-	    throw new Error('process.binding is not supported');
-	};
-
-	process.cwd = function () { return '/' };
-	process.chdir = function (dir) {
-	    throw new Error('process.chdir is not supported');
-	};
-	process.umask = function() { return 0; };
 
 
 /***/ },
-/* 17 */
+/* 21 */
 /***/ function(module, exports) {
 
 	module.exports = require("lru-cache");
 
 /***/ },
-/* 18 */
+/* 22 */
 /***/ function(module, exports) {
 
 	module.exports = require("lodash");

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function lastLogCheckpoint(req, res) {
       token: ctx.data.SPLUNK_TOKEN,
       url: ctx.data.SPLUNK_URL,
       port: ctx.data.SPLUNK_COLLECTOR_PORT || 8088,
+      path: ctx.data.SPLUNK_COLLECTOR_PATH || '/services/collector/event/1.0',
       maxBatchCount: 0 // Manually flush events
     };
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const memoizer = require('lru-memoizer');
 
 function lastLogCheckpoint(req, res) {
   let ctx = req.webtaskContext;
-  let required_settings = ['AUTH0_DOMAIN', 'AUTH0_CLIENT_ID', 'AUTH0_CLIENT_SECRET', 'SPLUNK_URL', 'SPLUNK_TOKEN', 'SPLUNK_COLLECTOR_PORT'];
+  let required_settings = ['AUTH0_DOMAIN', 'AUTH0_CLIENT_ID', 'AUTH0_CLIENT_SECRET', 'SPLUNK_URL', 'SPLUNK_TOKEN'];
   let missing_settings = required_settings.filter((setting) => !ctx.data[setting]);
 
   if (missing_settings.length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-logs-to-splunk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "This extension will take all of your Auth0 logs and export them to Splunk.",
   "main": "index.js",
   "scripts": {

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 Logs to Splunk",
   "name": "auth0-logs-to-splunk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "auth0",
   "description": "This extension will take all of your Auth0 logs and export them to Splunk",
   "type": "cron",
@@ -26,8 +26,13 @@
     },
     "SPLUNK_COLLECTOR_PORT": {
       "description": "HTTP Collector Port",
-      "required": true,
+      "required": false,
       "default": 8088
+    },
+    "SPLUNK_COLLECTOR_PATH": {
+      "description": "HTTP Collector Path (Endpoint)",
+      "required": false,
+      "default": "/services/collector/event/1.0"
     },
     "BATCH_SIZE": {
       "description": "The ammount of logs to be read on each execution. Maximun is 100.",


### PR DESCRIPTION
The Splunk HTTP collector supports [various endpoints](http://dev.splunk.com/view/event-collector/SP-CAAAE7H).

This PR enables the extension to receive the path as a parameter to pass it over to the `splunk-logging` instance.

Also, there are some other minor fixes for consistency.
