### PR TITLE
2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-logs-to-splunk",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "This extension will take all of your Auth0 logs and export them to Splunk.",
   "main": "index.js",
   "scripts": {

--- a/webtask.json
+++ b/webtask.json
@@ -5,6 +5,7 @@
   "author": "auth0",
   "description": "This extension will take all of your Auth0 logs and export them to Splunk",
   "type": "cron",
+  "initialUrlPath": "/login",
   "category": "log_export",
   "repository": "https://github.com/auth0-extensions/auth0-logs-to-splunk",
   "docsUrl": "https://auth0.com/docs/extensions/splunk",

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Auth0 Logs to Splunk",
   "name": "auth0-logs-to-splunk",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": "auth0",
   "description": "This extension will take all of your Auth0 logs and export them to Splunk",
   "type": "cron",


### PR DESCRIPTION
Pointing the extension to the new UI instead of the cron view.  Currently this causes an error for dashboard admins.  Instead of seeing the cron view they get a deprecation message and are re-routed to the webtask settings page.